### PR TITLE
feat: configurable connection parameters

### DIFF
--- a/src/main/java/com/worldql/client/WorldQLClient.java
+++ b/src/main/java/com/worldql/client/WorldQLClient.java
@@ -24,18 +24,23 @@ public class WorldQLClient extends JavaPlugin {
     public void onEnable() {
         pluginInstance = this;
         getLogger().info("Initializing Mammoth WorldQL client.");
+        saveDefaultConfig();
+
+        String worldqlHost = getConfig().getString("worldql.host", "127.0.0.1");
+        int worldqlPushPort = getConfig().getInt("worldql.push-port", 5555);
+        int worldqlHandshakePort = getConfig().getInt("worldql.handshake-port", 5556);
+
         context = new ZContext();
         pushSocket = context.createSocket(SocketType.PUSH);
         packetReader = new PacketReader();
         ZMQ.Socket handshakeSocket = context.createSocket(SocketType.REQ);
-        handshakeSocket.connect("tcp://127.0.0.1:5556");
+        handshakeSocket.connect("tcp://%s:%d".formatted(worldqlHost, worldqlHandshakePort));
 
-
-        String myIP = "127.0.0.1";
+        String selfHostname = getConfig().getString("host", "127.0.0.1");
         /*
         try (final DatagramSocket datagramSocket = new DatagramSocket()) {
             datagramSocket.connect(InetAddress.getByName("8.8.8.8"), 10002);
-            myIP = datagramSocket.getLocalAddress().getHostAddress();
+            selfHostname = datagramSocket.getLocalAddress().getHostAddress();
         } catch (Exception e) {
             throw new RuntimeException("Couldn't determine our IP address.");
         }
@@ -56,12 +61,12 @@ public class WorldQLClient extends JavaPlugin {
             getLogger().severe(e.getMessage());
         }
 
-        handshakeSocket.send(myIP.getBytes(ZMQ.CHARSET), 0);
+        handshakeSocket.send(selfHostname.getBytes(ZMQ.CHARSET), 0);
         byte[] reply = handshakeSocket.recv(0);
         String assignedZeroMQPort = new String(reply, ZMQ.CHARSET);
         zmqPortClientId = Integer.parseInt(assignedZeroMQPort);
 
-        pushSocket.connect("tcp://127.0.0.1:5555");
+        pushSocket.connect("tcp://%s:%d".formatted(worldqlHost, worldqlPushPort));
 
         getServer().getPluginManager().registerEvents(new PlayerMoveAndLookHandler(), this);
         getServer().getPluginManager().registerEvents(new PlayerJoinEventListener(), this);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,8 @@
+# WorldQL Connection Details
+worldql:
+  host: '127.0.0.1'
+  push-port: 5555
+  handshake-port: 5556
+
+# Client (self) Host
+host: '127.0.0.1'


### PR DESCRIPTION
Would be nice if the WorldQL server could resolve the host of the client from the existing connection, avoiding having to configure it manually.